### PR TITLE
rb-mock to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 2.3.85
 - name: rb-mock
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote rb-mock to version 0.0.2